### PR TITLE
Idiomatic kotlin

### DIFF
--- a/src/commonMain/kotlin/com/github/nanoflakes/DefaultNanoflakeWithEpochGenerator.kt
+++ b/src/commonMain/kotlin/com/github/nanoflakes/DefaultNanoflakeWithEpochGenerator.kt
@@ -1,0 +1,22 @@
+package com.github.nanoflakes
+
+/**
+ * A generator of [nanoflakes][Nanoflake] that retains its epoch information.
+ */
+class DefaultNanoflakeWithEpochGenerator(
+    private val generator: NanoflakeGenerator
+) : NanoflakeWithEpochGenerator, NanoflakeGenerator by generator {
+    override fun next(): NanoflakeWithEpoch {
+        return when (val nanoflake = generator.next()) {
+            is NanoflakeWithEpoch -> nanoflake
+            is PrimitiveNanoflake -> nanoflake.withEpoch(generator.epoch)
+        }
+    }
+}
+
+fun NanoflakeGenerator.withEpoch(): NanoflakeWithEpochGenerator {
+    return when (this) {
+        is NanoflakeWithEpochGenerator -> this
+        else -> DefaultNanoflakeWithEpochGenerator(this)
+    }
+}

--- a/src/commonMain/kotlin/com/github/nanoflakes/Nanoflake.kt
+++ b/src/commonMain/kotlin/com/github/nanoflakes/Nanoflake.kt
@@ -9,12 +9,26 @@ public sealed interface Nanoflake {
      */
     public val value: Long
 
+    /**
+     * The timestamp of the nanoflake.
+     */
     public val timestamp get() = Nanoflakes.timestampValue(value)
 
+    /**
+     * The generator ID of the nanoflake.
+     */
     public val generator get() = Nanoflakes.generatorValue(value)
 
+    /**
+     * The sequence number of the nanoflake.
+     */
     public val sequence get() = Nanoflakes.sequenceValue(value)
 
+    public operator fun component0() = timestamp
+
+    public operator fun component1() = generator
+
+    public operator fun component2() = sequence
 
     /**
      * Gets the nanoflake value as a Long.

--- a/src/commonMain/kotlin/com/github/nanoflakes/Nanoflake.kt
+++ b/src/commonMain/kotlin/com/github/nanoflakes/Nanoflake.kt
@@ -3,57 +3,25 @@ package com.github.nanoflakes
 /**
  * A [Nanoflake](https://github.com/nanoflakes/nanoflakes).
  */
-class Nanoflake {
-    /**
-     * The base epoch of the nanoflake.
-     */
-    private val epoch: Long
-
+public sealed interface Nanoflake {
     /**
      * The value of the nanoflake.
      */
-    private val value: Long
+    public val value: Long
 
-    /**
-     * Creates a new nanoflake.
-     *
-     * @param epoch the nanoflake's epoch.
-     * @param value the nanoflake's value.
-     */
-    constructor(epoch: Long, value: Long) {
-        this.epoch = epoch
-        this.value = value
-    }
+    public val timestamp get() = Nanoflakes.timestampValue(value)
 
-    /**
-     * Creates a new nanoflake, parsing the value from a string.
-     *
-     * @param epoch the nanoflake's epoch.
-     * @param value the nanoflake's value.
-     */
-    constructor(epoch: Long, value: String) {
-        this.epoch = epoch
-        this.value = value.toLong()
-    }
+    public val generator get() = Nanoflakes.generatorValue(value)
 
-    /**
-     * Creates a new nanoflake, parsing the value from a string with a radix.
-     *
-     * @param epoch the nanoflake's epoch.
-     * @param value the nanoflake's value.
-     * @param radix the radix of the nanoflake.
-     */
-    constructor(epoch: Long, value: String, radix: Int) {
-        this.epoch = epoch
-        this.value = value.toLong(radix)
-    }
+    public val sequence get() = Nanoflakes.sequenceValue(value)
+
 
     /**
      * Gets the nanoflake value as a Long.
      *
      * @return the value as a long.
      */
-    fun asLong(): Long {
+    public fun asLong(): Long {
         return value
     }
 
@@ -62,7 +30,7 @@ class Nanoflake {
      *
      * @return the value as a String.
      */
-    fun asString(): String {
+    public fun asString(): String {
         return value.toString()
     }
 
@@ -72,66 +40,19 @@ class Nanoflake {
      * @param radix the radix.
      * @return the value as a String.
      */
-    fun withRadix(radix: Int): String {
+    public fun withRadix(radix: Int): String {
         return value.toString(radix)
     }
+}
 
-    /**
-     * Gets the creation time as an [OffsetDateTime].
-     *
-     * @return a [OffsetDateTime] set to the creation time.
-     */
-    fun creationTime(): DateTime {
-        return creationTimeMillis().toDateTime()
-    }
+public fun nanoflake(value: Long): PrimitiveNanoflake {
+    return PrimitiveNanoflake(value)
+}
 
-    /**
-     * Gets the creation time.
-     *
-     * @return the creation time in milliseconds.
-     */
-    fun creationTimeMillis(): Long {
-        return epoch + Nanoflakes.timestampValue(value)
-    }
+public fun nanoflake(value: String): PrimitiveNanoflake {
+    return PrimitiveNanoflake(value.toLong())
+}
 
-    /**
-     * Gets this nanoflake's epoch.
-     *
-     * @return the epoch in milliseconds.
-     */
-    fun epochMillis(): Long {
-        return epoch
-    }
-
-    /**
-     * Gets this nanoflake's epoch as an [OffsetDateTime].
-     *
-     * @return a [OffsetDateTime] set to the epoch time.
-     */
-    fun epoch(): DateTime {
-        return epochMillis().toDateTime()
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || other !is Nanoflake) return false
-        return epoch == other.epoch && value == other.value
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    override fun hashCode(): Int {
-        return arrayOf<Any?>(epoch, value).contentHashCode()
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    override fun toString(): String {
-        return "Nanoflake{epoch=$epoch, value=$value}"
-    }
+public fun nanoflake(value: String, radix: Int): PrimitiveNanoflake {
+    return PrimitiveNanoflake(value.toLong(radix))
 }

--- a/src/commonMain/kotlin/com/github/nanoflakes/NanoflakeGenerator.kt
+++ b/src/commonMain/kotlin/com/github/nanoflakes/NanoflakeGenerator.kt
@@ -5,25 +5,19 @@ package com.github.nanoflakes
  */
 interface NanoflakeGenerator {
     /**
+     * This nanoflake generator's epoch.
+     */
+    val epoch: Long
+
+    /**
+     * This nanoflake generator's epoch as a [DateTime].
+     */
+    val epochDate: DateTime get() = epoch.toDateTime()
+
+    /**
      * Gets the next [nanoflake][Nanoflake].
      *
      * @return a new, generated nanoflake.
      */
     operator fun next(): Nanoflake
-
-    /**
-     * Gets this nanoflake generator's epoch.
-     *
-     * @return the epoch in milliseconds.
-     */
-    fun epochMillis(): Long
-
-    /**
-     * Gets this nanoflake generator's epoch as an [OffsetDateTime].
-     *
-     * @return a [OffsetDateTime] set to the epoch time.
-     */
-    fun NanoflakeGenerator.epoch(): DateTime {
-        return epochMillis().toDateTime()
-    }
 }

--- a/src/commonMain/kotlin/com/github/nanoflakes/NanoflakeLocalGenerator.kt
+++ b/src/commonMain/kotlin/com/github/nanoflakes/NanoflakeLocalGenerator.kt
@@ -15,7 +15,7 @@ class NanoflakeLocalGenerator(private val epoch: Long, private val generatorId: 
     private var lastTimestamp = -1L
     private var sequence = 0L
 
-    override fun next(): Nanoflake {
+    override fun next(): NanoflakeWithEpoch {
         var timestamp: Long = currentTimeMillis()
         if (timestamp < lastTimestamp) {
             throw RuntimeException("Clock moved backwards. Refusing to generate for " + (lastTimestamp - timestamp) + "milliseconds.")
@@ -29,7 +29,7 @@ class NanoflakeLocalGenerator(private val epoch: Long, private val generatorId: 
             }
             lastTimestamp = timestamp
             val value = timestamp - epoch shl TIMESTAMP_SHIFT or (generatorId shl GENERATOR_ID_SHIFT) or sequence
-            return Nanoflake(epoch, value)
+            return Nanoflake(value).withEpoch(epoch)
         }
     }
 

--- a/src/commonMain/kotlin/com/github/nanoflakes/NanoflakeWIthEpochGenerator.kt
+++ b/src/commonMain/kotlin/com/github/nanoflakes/NanoflakeWIthEpochGenerator.kt
@@ -1,0 +1,8 @@
+package com.github.nanoflakes
+
+/**
+ * A generator of [nanoflakes][Nanoflake] that retains its epoch information.
+ */
+public interface NanoflakeWithEpochGenerator : NanoflakeGenerator {
+    override fun next(): NanoflakeWithEpoch
+}

--- a/src/commonMain/kotlin/com/github/nanoflakes/NanoflakeWithEpoch.kt
+++ b/src/commonMain/kotlin/com/github/nanoflakes/NanoflakeWithEpoch.kt
@@ -1,0 +1,35 @@
+package com.github.nanoflakes
+
+/**
+ * A [Nanoflake] which contains epoch information.
+ *
+ * @param nanoflake the underlying nanoflake information.
+ * @param epochInMillis the nanoflake's epoch.
+ */
+public data class NanoflakeWithEpoch(
+    override val value: Long,
+    val epochInMillis: Long,
+): Nanoflake {
+    /**
+     * Gets this nanoflake's epoch as an [OffsetDateTime].
+     *
+     * @return a [OffsetDateTime] set to the epoch time.
+     */
+    public val epoch get() = epochInMillis.toDateTime()
+
+    /**
+     * The creation time.
+     */
+    val creationTimeInMillis get() = epochInMillis + timestamp
+
+    /**
+     * Gets the creation time as an [OffsetDateTime].
+     *
+     * @return a [OffsetDateTime] set to the creation time.
+     */
+    val creationTime get() = creationTimeInMillis.toDateTime()
+}
+
+public fun Nanoflake.withEpoch(epoch: Long): NanoflakeWithEpoch {
+    return NanoflakeWithEpoch(value, epoch)
+}

--- a/src/commonMain/kotlin/com/github/nanoflakes/Nanoflakes.kt
+++ b/src/commonMain/kotlin/com/github/nanoflakes/Nanoflakes.kt
@@ -43,10 +43,20 @@ object Nanoflakes {
      * Creates a local generator.
      * @param epoch base epoch
      * @param generatorId the generator id.
-     * @return a new local nanoflake generator.
+     * @return a new [NanoflakeLocalGenerator].
      */
     fun localGenerator(epoch: Long, generatorId: Long): NanoflakeGenerator {
         return NanoflakeLocalGenerator(epoch, generatorId)
+    }
+
+    /**
+     * Creates a local generator that keeps epoch information in the resulting nanoflake.
+     * @param epoch base epoch
+     * @param generatorId the generator id.
+     * @return a new local nanoflake generator.
+     */
+    fun withEpochLocalGenerator(epoch: Long, generatorId: Long): NanoflakeWithEpochGenerator {
+        return localGenerator(epoch, generatorId).withEpoch()
     }
 
     /**

--- a/src/commonMain/kotlin/com/github/nanoflakes/PrimitiveNanoflake.kt
+++ b/src/commonMain/kotlin/com/github/nanoflakes/PrimitiveNanoflake.kt
@@ -1,0 +1,62 @@
+package com.github.nanoflakes
+
+/**
+ * A [Nanoflake](https://github.com/nanoflakes/nanoflakes).
+ */
+class PrimitiveNanoflake : Nanoflake {
+    /**
+     * The value of the nanoflake.
+     */
+    override val value: Long
+
+    /**
+     * Creates a new nanoflake.
+     *
+     * @param value the nanoflake's value.
+     */
+    constructor(value: Long) {
+        this.value = value
+    }
+
+    /**
+     * Creates a new nanoflake, parsing the value from a string.
+     *
+     * @param value the nanoflake's value.
+     */
+    constructor(value: String) {
+        this.value = value.toLong()
+    }
+
+    /**
+     * Creates a new nanoflake, parsing the value from a string with a radix.
+     *
+     * @param value the nanoflake's value.
+     * @param radix the radix of the nanoflake.
+     */
+    constructor(value: String, radix: Int) {
+        this.value = value.toLong(radix)
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || other !is Nanoflake) return false
+        return value == other.value
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    override fun hashCode(): Int {
+        return arrayOf<Any?>(value).contentHashCode()
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    override fun toString(): String {
+        return "Nanoflake{value=$value}"
+    }
+}

--- a/src/commonMain/kotlin/com/github/nanoflakes/PrimitiveNanoflake.kt
+++ b/src/commonMain/kotlin/com/github/nanoflakes/PrimitiveNanoflake.kt
@@ -1,62 +1,11 @@
 package com.github.nanoflakes
 
+import kotlin.jvm.JvmInline
+
 /**
  * A [Nanoflake](https://github.com/nanoflakes/nanoflakes).
+ *
+ * @param value the value of the nanoflake.
  */
-class PrimitiveNanoflake : Nanoflake {
-    /**
-     * The value of the nanoflake.
-     */
-    override val value: Long
-
-    /**
-     * Creates a new nanoflake.
-     *
-     * @param value the nanoflake's value.
-     */
-    constructor(value: Long) {
-        this.value = value
-    }
-
-    /**
-     * Creates a new nanoflake, parsing the value from a string.
-     *
-     * @param value the nanoflake's value.
-     */
-    constructor(value: String) {
-        this.value = value.toLong()
-    }
-
-    /**
-     * Creates a new nanoflake, parsing the value from a string with a radix.
-     *
-     * @param value the nanoflake's value.
-     * @param radix the radix of the nanoflake.
-     */
-    constructor(value: String, radix: Int) {
-        this.value = value.toLong(radix)
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || other !is Nanoflake) return false
-        return value == other.value
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    override fun hashCode(): Int {
-        return arrayOf<Any?>(value).contentHashCode()
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    override fun toString(): String {
-        return "Nanoflake{value=$value}"
-    }
-}
+@JvmInline
+value class PrimitiveNanoflake(override val value: Long) : Nanoflake


### PR DESCRIPTION
This is one of three PRs I plan to submit. The purpose of this PR is to address most of the code-related design improvements discussed in https://github.com/nanoflakes/nanoflakes-kotlin/issues/1#issuecomment-1272404214. 

The changes consist of the following:
- A `Nanoflake` is made into a sealed interface. It can either be a `PrimitiveNanoflake` which is simply the value class of the long value (erases overhead!). There is also `NanoflakeWithEpoch` that takes the value of the nanoflake AND an additional epoch field. 
- Adds destructuring to nanoflakes.
- Adds convenience methods to a Nanoflake in order to avoid calling `Nanoflakes.xValue` directly.